### PR TITLE
Audio playback testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@ To optimize network usage, Weevil caches downloaded videos. Users can choose the
 
 
 ## Requirements
-- VLC
-    - somwhere around version 2.8.0
-    - Make sure you have your EV set up
-    - If you are using a 64bit machine, make sure you have that version of VLC installed
 - Python v.3.0.0 and above
 
 

--- a/mpWrapper.py
+++ b/mpWrapper.py
@@ -1,7 +1,10 @@
-import vlc, time, enum, threading, os
+import enum
+import threading
+import time
+import pyglet
+import os
 from icecream import ic
 import settings
-
 
 class MediaPlayerState(enum.Enum):
     NONE = -1
@@ -12,19 +15,16 @@ class MediaPlayerState(enum.Enum):
     LOADED = 5
     ROLL_BACK = 6
 
-
-
 class MediaPlayer:
     def __init__(self) -> None:
         self.state = MediaPlayerState.NONE
-        self.vlc_mediaPlayer:vlc.MediaPlayer = None
+        self.player = None
         self.on_state_change = threading.Event()
-        self.title:str = None
-        self.length:int = None
-        self.decay_thread:threading.Thread = None
+        self.title = None
+        self.length = None
+        self.decay_thread = None
 
-
-    def set_state(self, value:MediaPlayerState) -> MediaPlayerState:
+    def set_state(self, value: MediaPlayerState) -> MediaPlayerState:
         self.state = value
         self.on_state_change.set()
         return value
@@ -35,85 +35,75 @@ class MediaPlayer:
 
     def get_new_state(self) -> MediaPlayerState:
         self.on_state_change.wait()
-        return self.get_state_once()        
-
+        return self.get_state_once()
 
     def play(self) -> None:
-        if (self.vlc_mediaPlayer is None):
+        if self.player is None:
             return
         
         ic(self.set_state(MediaPlayerState.PLAYING))
-        ic(self.vlc_mediaPlayer.play())
+        self.player.play()
 
         def decay_state():
-            # wait for it to start playing
-            while (self.vlc_mediaPlayer.is_playing() != 1 and
-                MediaPlayerState.STOPPED != self.state):
+            while self.player.playing != 1 and self.state != MediaPlayerState.STOPPED:
                 time.sleep(0.05)
-            # wait for playback to finish
-            while (self.vlc_mediaPlayer.is_playing() == 1 or 
-                self.state == MediaPlayerState.PAUSED):
+            
+            while self.player.playing == 1 or self.state == MediaPlayerState.PAUSED:
                 time.sleep(0.05)
-            # handle a stop
+            
             ic(self.stop())
 
         if self.decay_thread is None:
             self.decay_thread = threading.Thread(target=decay_state, args=[], daemon=True)
-            self.decay_thread.start()      
+            self.decay_thread.start()
             ic(self.decay_thread)
 
     def load(self, mediaSource, title=None, length=None) -> None:
         self.title = title
         self.length = length
-        if self.vlc_mediaPlayer is not None: self.vlc_mediaPlayer.release()
-        self.vlc_mediaPlayer = vlc.Instance().media_player_new()
-        self.vlc_mediaPlayer.set_media(vlc.Instance().media_new(mediaSource))
+        self.player = pyglet.media.Player()
+        source = pyglet.media.load(mediaSource)
+        self.player.queue(source)
         ic(self.set_state(MediaPlayerState.LOADED))
         ic(settings.get("volume"))
-        ic(self.set_volume(int(settings.get("volume"))))
+        self.set_volume(int(settings.get("volume")))
 
     def next(self) -> None:
         ic(self.set_state(MediaPlayerState.SKIPPING))
-        if (self.vlc_mediaPlayer is not None):
-            self.vlc_mediaPlayer.set_pause(1)
+        if self.player is not None:
+            self.player.pause()
 
     def prev(self) -> None:
         ic(self.set_state(MediaPlayerState.ROLL_BACK))
-        if (self.vlc_mediaPlayer is not None):
-            self.vlc_mediaPlayer.set_pause(1)
+        if self.player is not None:
+            self.player.pause()
 
     def pause(self) -> None:
         ic(self.set_state(MediaPlayerState.PAUSED))
-        if (self.vlc_mediaPlayer is not None):
-            self.vlc_mediaPlayer.set_pause(1)
+        if self.player is not None:
+            self.player.pause()
 
     def resume(self) -> None:
         ic(self.set_state(MediaPlayerState.PLAYING))
-        if (self.vlc_mediaPlayer is not None):
-            self.vlc_mediaPlayer.set_pause(0)
-        # TODO: Find the underlying issue and create an actual fix
-        # Quick fix for https://github.com/0qln/Weevil/issues/7  
-        # time.sleep(0.003)
-        # empty_line = " " * os.get_terminal_size().columns
-        # for _ in range(2): print(f"\033[A{empty_line}\033[A")
+        if self.player is not None:
+            self.player.play()
 
     def set_volume(self, value) -> bool:
-        result = -1
-        if (self.vlc_mediaPlayer is not None):
-            result = self.vlc_mediaPlayer.audio_set_volume(int(value))
-        return result == 0
+        if self.player is not None:
+            self.player.volume = value / 100
+            return True
+        return False
 
     def get_volume(self) -> int:
-        result = -1
-        if (self.vlc_mediaPlayer is not None):
-            result = self.vlc_mediaPlayer.audio_get_volume()
-        return result
+        if self.player is not None:
+            return int(self.player.volume * 100)
+        return -1
 
     def stop(self) -> None:
         ic(self.set_state(MediaPlayerState.STOPPED))
-        if (self.vlc_mediaPlayer is not None):
-            self.vlc_mediaPlayer.set_pause(1)
-    
+        if self.player is not None:
+            self.player.pause()
+
     def get_duration(self) -> int:
         return self.length
 


### PR DESCRIPTION
replaces the underlying media player library in the MediaPlayer class from vlc to pyglet. The class methods and functionalities have been adapted to utilize pyglet's media handling features.

- Replaced vlc.MediaPlayer with pyglet.media.Player for media playback
- Modified methods such as play(), load(), pause(), resume(), stop(), set_volume(), get_volume(), next(), prev(), get_duration(), and get_content_title() to work with pyglet equivalents
- Updated state management and threading to fit pyglet's asynchronous behavior
- Fix issue https://github.com/0qln/Weevil/issues/7, as it was caused by the vlc library
- Unrestricted from VLC shenanigans

This change enhances compatibility and reduces dependencies by using pyglet, a widely used multimedia library in the Python ecosystem.